### PR TITLE
Announce Dr.Dromo limited beta

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,7 +3,20 @@ title: "Changelog"
 description: "Review Dromo product releases, new SDK and API capabilities, behavior changes, accessibility improvements, and bug fixes."
 ---
 
-<Update label="July 2026" description="v3.13.0" tags={["Customization", "Styling", "AI", "Review Step", "Prompts"]}>
+<Update label="July 2026" description="v3.13.0" tags={["Customization", "Styling", "AI", "Beta", "Review Step", "Prompts"]}>
+
+## Dr.Dromo Enters Limited Beta
+
+Meet **Dr.Dromo**, Dromo's AI assistant for designing and refining import workflows. Describe the outcome you need in plain language, and Dr.Dromo can help turn it into a reviewable Dromo schema.
+
+During the beta, Dr.Dromo can:
+
+- Generate import schemas from natural-language prompts, sample files, or existing configurations
+- Update fields, validation rules, settings, and hooks directly in Schema Studio
+- Provide product and implementation guidance grounded in Dromo's developer documentation
+- Present every proposed change for review before it is applied
+
+Dr.Dromo is currently available to a limited group of customers while we gather feedback and expand its capabilities. To request early access, contact [Dromo Support](mailto:support@dromo.io) or start a conversation using the support chat in the dashboard.
 
 ## Session Hydration Security
 


### PR DESCRIPTION
## What changed

- add a July 2026 changelog entry announcing the Dr.Dromo limited beta
- summarize its current schema generation, Schema Studio refinement, and documentation guidance capabilities
- clarify that proposed schema changes remain reviewable before they are applied
- direct interested customers to Dromo Support for early access

## Why

Dr.Dromo is entering limited beta and needs a clear, customer-facing announcement that sets accurate expectations and provides an access path.

## Validation

- `git diff --check` passed
- Mintlify link validation found no new broken links; the repository still has 12 pre-existing broken references
